### PR TITLE
Update workflows to run on pull_request events

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: 'Continuous Integration'
 
-on: [push]
+on: pull_request
 
 jobs:
   test:

--- a/.github/workflows/setup-zarf.yml
+++ b/.github/workflows/setup-zarf.yml
@@ -1,6 +1,7 @@
 name: 'Setup Zarf'
 
-on: [push]
+on: pull_request
+
 jobs:
   setup-zarf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, workflows in this repo run on push events, but would like to require a pull request to be created/opened before running CI