### PR TITLE
#25: Add grype syft

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Grype Report
-        path: ${{ steps.scan.outputs }}
+        path: ${{ steps.scan.outputs.sarif }}
 
     - name: Set commit short sha var as output
       id: short-sha-var

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,13 +8,33 @@ on:
       - main
 
 jobs:
-  test:
+  test-windows-mac:
     name: Cross-platform Test
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
 
+    - name: Setup Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+
+    - name: Install Package Dependencies
+      run: npm ci
+
+    - name: Test
+      run: npm test
+      shell: bash
+
+  test-ubuntu:
+    name: ubuntu
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
 
@@ -32,7 +52,6 @@ jobs:
 
     - name: Scan current project directory
       uses: anchore/scan-action@v3
-      runs-on: ubuntu-latest
       id: scan
       with:
         path: "."

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,8 +53,9 @@ jobs:
         path: "."
         fail-build: true
         severity-cutoff: high
+        output-format: json
     
-    - name: Inspect action SARIF report
+    - name: Inspect action json report
       run: cat ${{ steps.scan.outputs.json }}
 
     - name: Upload Grype scan results as an artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -77,17 +77,17 @@ jobs:
       run: |
         GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
         echo "Commit short sha value: " $GITHUB_SHA_SHORT
-        echo "{GITHUB_SHA_SHORT}={$GITHUB_SHA_SHORT}" >> $GITHUB_ENV
+        echo "{GITHUB_SHA_SHORT}={$GITHUB_SHA_SHORT}" >> $GITHUB_OUTPUT
 
     - name: Create SBOM
       uses: anchore/sbom-action@v0
       with:
         format: spdx-json
-        output-file: "${{ github.event.repository.name }}-${{ env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.GITHUB_SHA_SHORT }}-sbom.spdx.json"
 
     - name: Scan SBOM
       uses: anchore/scan-action@v3
       with:
-        sbom: "${{ github.event.repository.name }}-${{ env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.GITHUB_SHA_SHORT }}-sbom.spdx.json"
         fail-build: true
         severity-cutoff: critical

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,32 +26,34 @@ jobs:
       shell: bash
 
   scan:
-    - name: Scan current project
-      needs: test
-      uses: anchore/scan-action@v3
-      id: scan
-      with:
-        path: "."
-        fail-build: true
-        severity-cutoff: critical
+    name: Scan current project directory
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anchore/scan-action@v3
+        id: scan
+        with:
+          path: "."
+          fail-build: true
+          severity-cutoff: critical
     
-    - name: Inspect action SARIF report
-      run: cat ${{ steps.scan.outputs.sarif }}
+      - name: Inspect action SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
 
-    - name: Upload Anchore scan SARIF report
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: ${{ steps.scan.outputs.sarif }}
+      - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
 
-    - name: Create SBOM
-      uses: anchore/sbom-action@v0
-      with:
-        format: spdx-json
-        output-file: "${{ github.event.repository.name }}-sbom.spdx.json"
+      - name: Create SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: "${{ github.event.repository.name }}-sbom.spdx.json"
 
-    - name: Scan SBOM
-      uses: anchore/scan-action@v3
-      with:
-        sbom: "${{ github.event.repository.name }}-sbom.spdx.json"
-        fail-build: true
-        severity-cutoff: critical
+      - name: Scan SBOM
+        uses: anchore/scan-action@v3
+        with:
+          sbom: "${{ github.event.repository.name }}-sbom.spdx.json"
+          fail-build: true
+          severity-cutoff: critical

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,20 +45,30 @@ jobs:
       - name: Inspect action SARIF report
         run: cat ${{ steps.scan.outputs.sarif }}
 
-      - name: Upload Anchore scan SARIF report
+      - name: Upload Anchore scan SARIF report for viewing 
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+
+      - name: Upload Grype scan results as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: AnchoreReports
+          path: ./anchore-reports/
+
+      - name: Set commit short sha var as output
+        id: short-sha-var
+        run: echo "short-sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Create SBOM
         uses: anchore/sbom-action@v0
         with:
           format: spdx-json
-          output-file: "${{ github.event.repository.name }}-sbom.spdx.json"
+          output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.short-sha }}-sbom.spdx.json"
 
       - name: Scan SBOM
         uses: anchore/scan-action@v3
         with:
-          sbom: "${{ github.event.repository.name }}-sbom.spdx.json"
+          sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.short-sha }}-sbom.spdx.json"
           fail-build: true
           severity-cutoff: critical

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,14 +31,12 @@ jobs:
       shell: bash
 
     - name: Scan current project directory
-      runs-on: ubuntu-latest
-      steps:
-        - uses: anchore/scan-action@v3
-          id: scan
-          with:
-            path: "."
-            fail-build: true
-            severity-cutoff: critical
+      uses: anchore/scan-action@v3
+      id: scan
+      with:
+        path: "."
+        fail-build: true
+        severity-cutoff: critical
     
     - name: Inspect action SARIF report
       run: cat ${{ steps.scan.outputs.sarif }}
@@ -52,7 +50,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Grype Report
-        path: ${{ steps.scan.outputs.sarif }}
+        path: ${{ steps.scan.outputs }}
 
     - name: Set commit short sha var as output
       id: short-sha-var
@@ -62,11 +60,11 @@ jobs:
       uses: anchore/sbom-action@v0
       with:
         format: spdx-json
-        output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
 
     - name: Scan SBOM
       uses: anchore/scan-action@v3
       with:
-        sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.short-sha }}-sbom.spdx.json"
+        sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
         fail-build: true
         severity-cutoff: critical

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,6 +33,9 @@ jobs:
         fail-build: true
         severity-cutoff: critical
     
+    - name: Inspect action SARIF report
+      run: cat ${{ steps.scan.outputs.sarif }}
+
     - name: Upload Anchore scan SARIF report
       uses: github/codeql-action/upload-sarif@v2
       with:
@@ -48,3 +51,5 @@ jobs:
       uses: anchore/scan-action@v3
       with:
         sbom: "${{ github.event.repository.name }}-sbom.spdx.json"
+        fail-build: true
+        severity-cutoff: critical

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,6 +30,8 @@ jobs:
       id: scan
       with:
         path: "."
+        fail-build: true
+        severity-cutoff: critical
     
     - name: Upload Anchore scan SARIF report
       uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,17 +74,20 @@ jobs:
 
     - name: Set commit short sha var as output
       id: short-sha-var
-      run: GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
+      run: |
+        GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
+        echo "Commit short sha value: " $GITHUB_SHA_SHORT
+        echo "{GITHUB_SHA_SHORT}={$GITHUB_SHA_SHORT}" >> $GITHUB_ENV
 
     - name: Create SBOM
       uses: anchore/sbom-action@v0
       with:
         format: spdx-json
-        output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        output-file: "${{ github.event.repository.name }}-${{ env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
 
     - name: Scan SBOM
       uses: anchore/scan-action@v3
       with:
-        sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        sbom: "${{ github.event.repository.name }}-${{ env.GITHUB_SHA_SHORT }}-sbom.spdx.json"
         fail-build: true
         severity-cutoff: critical

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,3 +24,25 @@ jobs:
     - name: Test
       run: npm test
       shell: bash
+
+    - name: Scan current project
+      uses: anchore/scan-action@v3
+      id: scan
+      with:
+        path: "."
+    
+    - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
+    - name: Create SBOM
+      uses: anchore/sbom-action@v0
+      with:
+        format: spdx-json
+        output-file: "${{ github.event.repository.name }}-sbom.spdx.json"
+
+    - name: Scan SBOM
+      uses: anchore/scan-action@v3
+      with:
+        sbom: "${{ github.event.repository.name }}-sbom.spdx.json"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,13 +56,13 @@ jobs:
         output-format: json
     
     - name: Inspect action json report
-      run: cat ${{ steps.scan.outputs.json }}
+      run: cat results.json
 
     - name: Upload Grype scan results as an artifact
       uses: actions/upload-artifact@v3
       with:
         name: Grype Report
-        path: ${{ steps.scan.outputs.json }}
+        path: ./results.json
 
     - name: Create SBOM
       uses: anchore/sbom-action@v0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,9 +32,9 @@ jobs:
         path: "."
     
     - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}
 
     - name: Create SBOM
       uses: anchore/sbom-action@v0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,6 +32,7 @@ jobs:
 
     - name: Scan current project directory
       uses: anchore/scan-action@v3
+      runs-on: ubuntu-latest
       id: scan
       with:
         path: "."

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,11 +8,11 @@ on:
       - main
 
 jobs:
-  test-windows-mac:
+  test-cross-platform:
     name: Cross-platform Test
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
       run: npm test
       shell: bash
 
-  test-ubuntu:
+  ubuntu-scan:
     name: ubuntu
     strategy:
       matrix:
@@ -46,48 +46,32 @@ jobs:
     - name: Install Package Dependencies
       run: npm ci
 
-    - name: Test
-      run: npm test
-      shell: bash
-
     - name: Scan current project directory
       uses: anchore/scan-action@v3
       id: scan
       with:
         path: "."
         fail-build: true
-        severity-cutoff: critical
+        severity-cutoff: high
     
     - name: Inspect action SARIF report
-      run: cat ${{ steps.scan.outputs.sarif }}
-
-    - name: Upload Anchore scan SARIF report for viewing 
-      uses: github/codeql-action/upload-sarif@v2
-      with:
-        sarif_file: ${{ steps.scan.outputs.sarif }}
+      run: cat ${{ steps.scan.outputs.json }}
 
     - name: Upload Grype scan results as an artifact
       uses: actions/upload-artifact@v3
       with:
         name: Grype Report
-        path: ${{ steps.scan.outputs.sarif }}
-
-    - name: Set commit short sha var as output
-      id: short-sha-var
-      run: |
-        GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
-        echo "Commit short sha value: " $GITHUB_SHA_SHORT
-        echo "{GITHUB_SHA_SHORT}={$GITHUB_SHA_SHORT}" >> $GITHUB_OUTPUT
+        path: ${{ steps.scan.outputs.json }}
 
     - name: Create SBOM
       uses: anchore/sbom-action@v0
       with:
         format: spdx-json
-        output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        output-file: "${{ github.event.repository.name }}-${{ github.sha }}-sbom.spdx.json"
 
     - name: Scan SBOM
       uses: anchore/scan-action@v3
       with:
-        sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.GITHUB_SHA_SHORT }}-sbom.spdx.json"
+        sbom: "${{ github.event.repository.name }}-${{ github.sha }}-sbom.spdx.json"
         fail-build: true
-        severity-cutoff: critical
+        severity-cutoff: high

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    name: Test
+    name: Cross-platform Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,7 +25,9 @@ jobs:
       run: npm test
       shell: bash
 
+  scan:
     - name: Scan current project
+      needs: test
       uses: anchore/scan-action@v3
       id: scan
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,45 +30,43 @@ jobs:
       run: npm test
       shell: bash
 
-  scan:
-    name: Scan current project directory
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: anchore/scan-action@v3
-        id: scan
-        with:
-          path: "."
-          fail-build: true
-          severity-cutoff: critical
+    - name: Scan current project directory
+      runs-on: ubuntu-latest
+      steps:
+        - uses: anchore/scan-action@v3
+          id: scan
+          with:
+            path: "."
+            fail-build: true
+            severity-cutoff: critical
     
-      - name: Inspect action SARIF report
-        run: cat ${{ steps.scan.outputs.sarif }}
+    - name: Inspect action SARIF report
+      run: cat ${{ steps.scan.outputs.sarif }}
 
-      - name: Upload Anchore scan SARIF report for viewing 
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
+    - name: Upload Anchore scan SARIF report for viewing 
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}
 
-      - name: Upload Grype scan results as an artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: AnchoreReports
-          path: ./anchore-reports/
+    - name: Upload Grype scan results as an artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: Grype Report
+        path: ${{ steps.scan.outputs.sarif }}
 
-      - name: Set commit short sha var as output
-        id: short-sha-var
-        run: echo "short-sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Set commit short sha var as output
+      id: short-sha-var
+      run: GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)
 
-      - name: Create SBOM
-        uses: anchore/sbom-action@v0
-        with:
-          format: spdx-json
-          output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.short-sha }}-sbom.spdx.json"
+    - name: Create SBOM
+      uses: anchore/sbom-action@v0
+      with:
+        format: spdx-json
+        output-file: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.GITHUB_SHA_SHORT }}-sbom.spdx.json"
 
-      - name: Scan SBOM
-        uses: anchore/scan-action@v3
-        with:
-          sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.short-sha }}-sbom.spdx.json"
-          fail-build: true
-          severity-cutoff: critical
+    - name: Scan SBOM
+      uses: anchore/scan-action@v3
+      with:
+        sbom: "${{ github.event.repository.name }}-${{ steps.short-sha-var.outputs.short-sha }}-sbom.spdx.json"
+        fail-build: true
+        severity-cutoff: critical

--- a/README.md
+++ b/README.md
@@ -64,3 +64,5 @@ This project utilizes a static code analysis tool called [eslint](https://eslint
 When changes are made to the javascript source code, run `npm run all` to execute `eslint` against the code and recompile the code into the `dist/index.js` file.
 
 &nbsp;
+
+


### PR DESCRIPTION
This adds grype and syft to the CI workflow

Grype - scans the project directory starting at the root level

Syft - generates an SBOM in SPDX format

This MR addresses the following ticket: https://github.com/defenseunicorns/setup-zarf/issues/25